### PR TITLE
fix: combo points

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -2203,6 +2203,11 @@ Private.event_prototypes = {
         AddUnitEventForEvents(result, unit, "UNIT_FLAGS")
       end
 
+      if trigger.powertype == 4 then
+        AddUnitEventForEvents(result, unit, "UNIT_TARGET")
+        AddUnitEventForEvents(result, unit, "UNIT_COMBO_POINTS")
+      end
+
       return result;
     end,
     internal_events = function(trigger)


### PR DESCRIPTION
# Description

Combo points power tiggers have some issues with current target's combo points, and Premeditation spell's combo point generations.

These issues come from combo points system rework (Wod) as far as I know.

## Type of change

- [x] Bug fix
